### PR TITLE
schemas: add agentic services contract layer

### DIFF
--- a/.github/workflows/validate-agentic-contracts.yml
+++ b/.github/workflows/validate-agentic-contracts.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
   push:
     branches: [ main ]
+permissions:
+  contents: read
+
 jobs:
   validate-agentic-contracts:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-agentic-contracts.yml
+++ b/.github/workflows/validate-agentic-contracts.yml
@@ -1,0 +1,15 @@
+name: validate-agentic-contracts
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+jobs:
+  validate-agentic-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --upgrade pip && pip install -r requirements-contracts.txt
+      - run: python scripts/validate_agentic_contracts.py

--- a/.github/workflows/validate-all-contracts.yml
+++ b/.github/workflows/validate-all-contracts.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
   push:
     branches: [ main ]
+permissions:
+  contents: read
+
 jobs:
   validate-all-contracts:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-all-contracts.yml
+++ b/.github/workflows/validate-all-contracts.yml
@@ -1,0 +1,15 @@
+name: validate-all-contracts
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+jobs:
+  validate-all-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --upgrade pip && pip install -r requirements-contracts.txt
+      - run: python scripts/validate_all_contracts.py

--- a/.github/workflows/validate-engagement-objects.yml
+++ b/.github/workflows/validate-engagement-objects.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
   push:
     branches: [ main ]
+permissions:
+  contents: read
+
 jobs:
   validate-engagement-objects:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-engagement-objects.yml
+++ b/.github/workflows/validate-engagement-objects.yml
@@ -1,0 +1,15 @@
+name: validate-engagement-objects
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+jobs:
+  validate-engagement-objects:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --upgrade pip && pip install -r requirements-contracts.txt
+      - run: python scripts/validate_engagement_objects.py

--- a/.github/workflows/validate-metadata-operations.yml
+++ b/.github/workflows/validate-metadata-operations.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
   push:
     branches: [ main ]
+permissions:
+  contents: read
+
 jobs:
   validate-metadata-operations:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-metadata-operations.yml
+++ b/.github/workflows/validate-metadata-operations.yml
@@ -1,0 +1,15 @@
+name: validate-metadata-operations
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+jobs:
+  validate-metadata-operations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --upgrade pip && pip install -r requirements-contracts.txt
+      - run: python scripts/validate_metadata_operations.py

--- a/.github/workflows/validate-payout-objects.yml
+++ b/.github/workflows/validate-payout-objects.yml
@@ -1,0 +1,15 @@
+name: validate-payout-objects
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+jobs:
+  validate-payout-objects:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --upgrade pip && pip install -r requirements-contracts.txt
+      - run: python scripts/validate_payout_objects.py

--- a/.github/workflows/validate-payout-objects.yml
+++ b/.github/workflows/validate-payout-objects.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
   push:
     branches: [ main ]
+permissions:
+  contents: read
+
 jobs:
   validate-payout-objects:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-service-catalog-and-sla.yml
+++ b/.github/workflows/validate-service-catalog-and-sla.yml
@@ -1,0 +1,15 @@
+name: validate-service-catalog-and-sla
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+jobs:
+  validate-service-catalog-and-sla:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --upgrade pip && pip install -r requirements-contracts.txt
+      - run: python scripts/validate_service_catalog_and_sla.py

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -1,0 +1,24 @@
+# START HERE — DelEx Automation Contracts
+
+This repository is the machine-readable contract and validation layer for DelEx-OS.
+
+## Read in this order
+
+1. `docs/README.md`
+2. `docs/validation-contract.md`
+3. `schemas/` for the current object model
+4. `examples/customer-success-support-accelerator.bundle.yaml`
+5. `scripts/validate_agentic_contracts.py`
+6. `schemas/engagement.schema.json`
+7. `scripts/validate_engagement_objects.py`
+
+## Primary role of this repo
+
+- encode the upstream DelEx method as schemas and examples
+- validate contract objects in CI
+- provide stable objects for downstream consumers
+
+## Upstream and downstream
+
+- Upstream prose canon lives in `delivery-excellence`
+- Downstream consumers are `delivery-excellence-boards` and `delivery-excellence-innersource`

--- a/automation/email/EMAIL_LISTS.yaml
+++ b/automation/email/EMAIL_LISTS.yaml
@@ -13,3 +13,11 @@ lists:
     address: security-review@EXAMPLE.INVALID
   - group_id: grp.broadcast.all
     address: platform-broadcast@EXAMPLE.INVALID
+  - group_id: grp.platform.sre
+    address: sre@EXAMPLE.INVALID
+  - group_id: grp.geo.na
+    address: geo-na@EXAMPLE.INVALID
+  - group_id: grp.geo.emea
+    address: geo-emea@EXAMPLE.INVALID
+  - group_id: grp.geo.ap
+    address: geo-ap@EXAMPLE.INVALID

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ This repository holds machine-readable contracts and validation surfaces for Del
 - `schemas/autonomy-envelope.schema.json`
 - `schemas/delivery-gate.schema.json`
 - `schemas/client-dependency.schema.json`
-- `examples/customer-success-support-accelerator.yaml`
+- `examples/customer-success-support-accelerator.bundle.yaml`
 - `docs/validation-contract.md`
 
 ## Design rule

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+# DelEx Automation Contract Layer
+
+This repository holds machine-readable contracts and validation surfaces for DelEx-OS.
+
+## Purpose
+
+- keep the human-readable canon in `delivery-excellence`
+- encode the same operating model as schemas and validation-ready config here
+- provide worked examples that downstream systems can consume
+
+## Primary artifacts
+
+- `schemas/autonomy-envelope.schema.json`
+- `schemas/delivery-gate.schema.json`
+- `schemas/client-dependency.schema.json`
+- `examples/customer-success-support-accelerator.yaml`
+- `docs/validation-contract.md`
+
+## Design rule
+
+If an object is normative for control, approval, or governance, it should have both:
+1. a prose definition upstream in `delivery-excellence`
+2. a machine-readable contract here

--- a/docs/validation-contract.md
+++ b/docs/validation-contract.md
@@ -1,0 +1,34 @@
+# Validation Contract
+
+## Goal
+
+Validation in this repo should prove that the machine-readable contract layer remains internally consistent and aligned to the human-readable method.
+
+## Validation scope
+
+### Referential integrity
+Already partly covered by the current config validator:
+- every referenced group ID must exist
+- every automated group must have a routable email mapping
+
+### Schema conformance
+New contract objects should validate against explicit schemas:
+- autonomy envelope
+- delivery gate
+- client dependency manifest
+
+### Policy integrity
+Later validation should also ensure:
+- A3 actions are reversible and explicitly marked as such
+- A4 actions are never marked as autonomous
+- approval requirements exist for every A2 action
+- every gate declares accountable roles and evidence requirements
+
+### Example validity
+Worked examples under `examples/` should validate cleanly against all referenced schemas.
+
+## Downstream consumers
+
+- `delivery-excellence-boards` should consume validated gate and workflow objects.
+- `delivery-excellence-innersource` should consume validated readiness and role objects.
+- `delivery-excellence-bounties` should consume validated evidence and gate-completion signals, not invent its own truth model.

--- a/examples/coc-service-catalog-and-sla.yaml
+++ b/examples/coc-service-catalog-and-sla.yaml
@@ -1,0 +1,38 @@
+service_catalog_entry:
+  version: "1"
+  service_id: svc.engagement.communication
+  service_name: Communication and Adoption Support
+  function_area: Engagement
+  service_area: Communication
+  owners:
+    - role.consulting.delivery-lead
+    - role.client.sponsor
+  success_kpis:
+    - number_of_events
+    - incoming_business_requests
+    - workshop_quality
+    - business_units_using_solutions
+  linked_delivery_gates:
+    - gate.readiness-baseline
+    - gate.controlled-action-pilot
+  linked_reusable_assets:
+    - asset.cs-support-autonomy-envelope-template
+  notes: Business-facing front door for governed AI service adoption.
+
+service_level_agreement:
+  version: "1"
+  sla_id: sla.engagement.communication.v1
+  service_id: svc.engagement.communication
+  service_name: Communication and Adoption Support
+  response_targets:
+    - acknowledge_request_within_2_business_days
+  resolution_targets:
+    - schedule_initial_workshop_within_10_business_days
+    - publish_followup_actions_within_3_business_days_after_workshop
+  measurement_method: Service desk timestamps plus workshop log review.
+  evidence_requirements:
+    - request_log
+    - workshop_attendance_log
+    - followup_action_record
+  escalation_policy_id: sla.metadata.high
+  notes: Applies to the initial engagement and adoption service line.

--- a/examples/customer-success-support-accelerator.bounty-policy.yaml
+++ b/examples/customer-success-support-accelerator.bounty-policy.yaml
@@ -1,0 +1,23 @@
+version: "1"
+policy_id: policy.customer-success.support-accelerator
+name: Customer Success Support Accelerator Bounty Policy
+service_offer_id: offer.customer-success.support-accelerator
+engagement_id: eng.customer-success.support-001
+allowed_reward_signals:
+  - validated_dependency_closure
+  - reusable_asset_promotion
+  - gate_supporting_validation_artifacts
+prohibited_reward_signals:
+  - raw_commit_count
+  - unreviewed_customer_facing_output
+  - bypassed_approval_path
+  - autonomy_expansion_without_gate_approval
+gate_requirements:
+  - gate.readiness-baseline
+  - gate.controlled-action-pilot
+required_approver_role: role.consulting.delivery-lead
+payout_ceiling_amount: 5000
+currency: USD
+requires_evidence_validation: true
+requires_gate_approval: true
+notes: Incentives reinforce proof-backed delivery only; they do not override DelEx controls.

--- a/examples/customer-success-support-accelerator.bundle.yaml
+++ b/examples/customer-success-support-accelerator.bundle.yaml
@@ -1,0 +1,251 @@
+service_offer:
+  version: "1"
+  offer_id: offer.customer-success.support-accelerator
+  name: Governed AI Customer Success and Support Accelerator
+  buyer_problem: Slow case handling, fragmented knowledge, inconsistent escalation, and weak operator leverage.
+  stages:
+    - readiness_and_design
+    - build_and_shadow
+    - controlled_action_pilot
+    - managed_assurance
+  excluded_actions:
+    - pricing_changes
+    - customer_compensation
+    - policy_exceptions
+    - destructive_production_changes
+  acceptance_model:
+    - phase_gate_acceptance
+    - evidence_backed_change_control
+  managed_service_follow_on: true
+  target_kpis:
+    - time_to_first_meaningful_response
+    - routing_accuracy
+    - intervention_rate
+    - csat
+
+control_loop:
+  version: "1"
+  control_loop_id: cl.customer-success.support-intake
+  trigger: inbound_case_or_support_request
+  context_sources:
+    - crm
+    - ticketing
+    - knowledge_base
+    - internal_notes
+  allowed_tools:
+    - retrieve_account_context
+    - retrieve_kb_articles
+    - draft_response
+    - route_ticket
+  action_classes:
+    - A0
+    - A1
+    - A2
+    - A3
+    - A4
+  approval_rule: Consequential or customer-binding actions require human approval; selected reversible internal actions may run under policy.
+  exception_route: policy_owner_or_support_ops_queue
+  emitted_evidence:
+    - source_links
+    - policy_check
+    - approval_record
+    - output_log
+  target_kpis:
+    - time_to_first_meaningful_response
+    - time_to_resolution
+    - routing_accuracy
+
+autonomy_envelope:
+  version: "1"
+  workflow_id: wf.customer-success.support-accelerator
+  owners:
+    business_owner: role.client.sponsor
+    policy_owner: role.client.policy-owner
+    operator_owner: role.client.support-ops
+  actions:
+    - id: action.call-summary
+      description: Summarize inbound call or case notes.
+      class: A0
+      mode: observe
+      reversible: true
+      requires_human_approval: false
+      evidence_required: [source_links, output_log]
+    - id: action.reply-draft
+      description: Draft customer-facing reply for operator review.
+      class: A1
+      mode: draft
+      reversible: true
+      requires_human_approval: true
+      evidence_required: [source_links, draft_artifact]
+    - id: action.ticket-route
+      description: Route ticket to the correct internal queue.
+      class: A2
+      mode: approval_gated
+      reversible: true
+      requires_human_approval: true
+      rollback_required: true
+      evidence_required: [approval_record, routing_log]
+    - id: action.internal-reminder
+      description: Send internal reminder or follow-up nudge.
+      class: A3
+      mode: policy_bounded_auto
+      reversible: true
+      requires_human_approval: false
+      rollback_required: true
+      evidence_required: [policy_check, audit_log]
+    - id: action.customer-compensation
+      description: Offer credit, compensation, or externally binding concession.
+      class: A4
+      mode: human_only
+      reversible: false
+      requires_human_approval: true
+      evidence_required: [approval_record, final_audit]
+
+delivery_gates:
+  - version: "1"
+    gate_id: gate.readiness-baseline
+    name: Readiness Baseline
+    required_maturity:
+      requirements: 2
+      dependencies: 2
+      knowledge: 2
+      evaluation: 1
+      governance: 1
+    required_evidence:
+      - process_map
+      - dependency_register
+      - action_class_matrix
+      - baseline_kpi_pack
+    accountable_roles:
+      - role.client.sponsor
+      - role.consulting.delivery-lead
+    exit_criteria:
+      - named owners confirmed
+      - workflow boundary approved
+  - version: "1"
+    gate_id: gate.controlled-action-pilot
+    name: Controlled Action Pilot
+    required_maturity:
+      requirements: 3
+      dependencies: 3
+      knowledge: 3
+      evaluation: 3
+      governance: 3
+    required_evidence:
+      - shadow_mode_report
+      - rollback_test
+      - intervention_dashboard
+      - policy_signoff
+    accountable_roles:
+      - role.client.policy-owner
+      - role.consulting.evaluation-lead
+    exit_criteria:
+      - approved A2/A3 subset
+      - exception queue staffed
+
+client_dependencies:
+  - version: "1"
+    dependency_id: dep.crm-access
+    system: CRM
+    owner: role.client.system-owner
+    access_state: ready
+    criticality: critical
+    blockers: []
+    failure_modes: [missing_account_context, stale_data]
+  - version: "1"
+    dependency_id: dep.kb-corpus
+    system: Knowledge Base
+    owner: role.client.knowledge-owner
+    access_state: provisioning
+    criticality: high
+    blockers: [metadata_cleanup]
+    failure_modes: [stale_articles, low_citation_coverage]
+
+exception_classes:
+  - version: "1"
+    exception_id: exc.policy-ambiguity
+    severity: high
+    trigger_condition: conflicting_policy_or_missing_approval_path
+    human_owner: role.client.policy-owner
+    resolution_target_hours: 4
+    stop_work: true
+    rollback_considered: true
+  - version: "1"
+    exception_id: exc.missing-context
+    severity: medium
+    trigger_condition: account_or_case_context_is_incomplete
+    human_owner: role.client.support-ops
+    resolution_target_hours: 8
+    stop_work: false
+    rollback_considered: false
+
+board_items:
+  - version: "1"
+    item_id: board.readiness-baseline
+    item_type: gate_review
+    linked_engagement: eng.customer-success.support-001
+    linked_control_loop: cl.customer-success.support-intake
+    current_gate: gate.readiness-baseline
+    owner: role.consulting.delivery-lead
+    priority: P1
+    blocked: false
+    evidence_links: [process_map, dependency_register]
+  - version: "1"
+    item_id: board.kb-cleanup
+    item_type: dependency
+    linked_engagement: eng.customer-success.support-001
+    linked_control_loop: cl.customer-success.support-intake
+    current_gate: gate.readiness-baseline
+    owner: role.client.knowledge-owner
+    priority: P1
+    blocked: true
+    evidence_links: [metadata_cleanup]
+
+reusable_assets:
+  - version: "1"
+    asset_id: asset.cs-support-autonomy-envelope-template
+    asset_type: template
+    owning_group: grp.governance.delex-core
+    source_engagements:
+      - eng.customer-success.support-001
+    evidence_of_reuse_value:
+      - faster_contracting
+      - consistent_control_boundaries
+    readiness_status: review
+
+customer_success_review:
+  version: "1"
+  review_id: csr.q2.customer-success.support-001
+  review_period: 2026-Q2
+  kpi_movement:
+    - time_to_first_meaningful_response_down_18_percent
+    - routing_accuracy_up_12_percent
+  intervention_summary: Intervention remains concentrated in A1 drafting and policy ambiguity exceptions.
+  trust_signal: Operators accept summaries and routing suggestions but still want strict review of customer-facing drafts.
+  proposed_scope_changes:
+    - expand_read_only_account_health_summaries
+  proposed_autonomy_changes:
+    - consider_narrower_A3_internal_reminders
+
+gate_review:
+  version: "1"
+  review_id: gr.controlled-action-pilot.customer-success.support-001
+  gate_id: gate.controlled-action-pilot
+  engagement_id: eng.customer-success.support-001
+  current_action_classes:
+    - A0
+    - A1
+    - A2
+    - A3
+    - A4
+  proposed_change: allow_policy_bounded_internal_reminders_after_shadow_validation
+  maturity_scores:
+    requirements: 3
+    dependencies: 3
+    knowledge: 3
+    evaluation: 3
+    governance: 3
+  decision: approved_with_constraints
+  follow_up_actions:
+    - prove_reminder_rollback
+    - maintain_100_percent_review_for_customer_facing_drafts

--- a/examples/customer-success-support-accelerator.engagement.yaml
+++ b/examples/customer-success-support-accelerator.engagement.yaml
@@ -1,0 +1,19 @@
+version: "1"
+engagement_id: eng.customer-success.support-001
+service_offer_id: offer.customer-success.support-accelerator
+sponsor: role.client.sponsor
+process_owner: role.client.support-process-owner
+system_owner: role.client.system-owner
+data_owner: role.client.knowledge-owner
+policy_owner: role.client.policy-owner
+operator_owner: role.client.support-ops
+target_workflow: wf.customer-success.support-accelerator
+current_gate: gate.readiness-baseline
+current_autonomy_classes:
+  - A0
+  - A1
+kpi_baseline:
+  - time_to_first_meaningful_response
+  - routing_accuracy
+  - intervention_rate
+notes: Initial bounded engagement before controlled-action pilot.

--- a/examples/customer-success-support-accelerator.payout.yaml
+++ b/examples/customer-success-support-accelerator.payout.yaml
@@ -1,0 +1,28 @@
+payout_decision:
+  version: "1"
+  payout_decision_id: pay.customer-success.support-001.readiness-baseline
+  engagement_id: eng.customer-success.support-001
+  gate_id: gate.readiness-baseline
+  status: approved
+  decision_owner: role.consulting.delivery-lead
+  evidence_links:
+    - process_map
+    - dependency_register
+    - metadata_cleanup
+  reusable_asset_ids:
+    - asset.cs-support-autonomy-envelope-template
+  exception_ids: []
+  escrow_reference_id: escrow.customer-success.support-001.readiness-baseline
+  amount: 2500
+  currency: USD
+  rationale: Approved for validated readiness-baseline dependency closure and reusable artifact support.
+
+escrow_reference:
+  version: "1"
+  escrow_reference_id: escrow.customer-success.support-001.readiness-baseline
+  instrument_type: internal_ledger
+  currency: USD
+  amount: 2500
+  external_reference: payout-ledger-placeholder
+  status: reserved
+  notes: No secrets, wallet keys, or private settlement material should be committed to git.

--- a/examples/customer-success-support-accelerator.yaml
+++ b/examples/customer-success-support-accelerator.yaml
@@ -1,0 +1,112 @@
+version: "1"
+workflow_id: wf.customer-success.support-accelerator
+owners:
+  business_owner: role.client.sponsor
+  policy_owner: role.client.policy-owner
+  operator_owner: role.client.support-ops
+
+autonomy_envelope:
+  version: "1"
+  workflow_id: wf.customer-success.support-accelerator
+  owners:
+    business_owner: role.client.sponsor
+    policy_owner: role.client.policy-owner
+    operator_owner: role.client.support-ops
+  actions:
+    - id: action.call-summary
+      description: Summarize inbound call or case notes.
+      class: A0
+      mode: observe
+      reversible: true
+      requires_human_approval: false
+      evidence_required: [source_links, output_log]
+    - id: action.reply-draft
+      description: Draft customer-facing reply for operator review.
+      class: A1
+      mode: draft
+      reversible: true
+      requires_human_approval: true
+      evidence_required: [source_links, draft_artifact]
+    - id: action.ticket-route
+      description: Route ticket to the correct internal queue.
+      class: A2
+      mode: approval_gated
+      reversible: true
+      requires_human_approval: true
+      rollback_required: true
+      evidence_required: [approval_record, routing_log]
+    - id: action.internal-reminder
+      description: Send internal reminder or follow-up nudge.
+      class: A3
+      mode: policy_bounded_auto
+      reversible: true
+      requires_human_approval: false
+      rollback_required: true
+      evidence_required: [policy_check, audit_log]
+    - id: action.customer-compensation
+      description: Offer credit, compensation, or externally binding concession.
+      class: A4
+      mode: human_only
+      reversible: false
+      requires_human_approval: true
+      evidence_required: [approval_record, final_audit]
+
+delivery_gates:
+  - version: "1"
+    gate_id: gate.readiness-baseline
+    name: Readiness Baseline
+    required_maturity:
+      requirements: 2
+      dependencies: 2
+      knowledge: 2
+      evaluation: 1
+      governance: 1
+    required_evidence:
+      - process_map
+      - dependency_register
+      - action_class_matrix
+      - baseline_kpi_pack
+    accountable_roles:
+      - role.client.sponsor
+      - role.consulting.delivery-lead
+    exit_criteria:
+      - named owners confirmed
+      - workflow boundary approved
+  - version: "1"
+    gate_id: gate.controlled-action-pilot
+    name: Controlled Action Pilot
+    required_maturity:
+      requirements: 3
+      dependencies: 3
+      knowledge: 3
+      evaluation: 3
+      governance: 3
+    required_evidence:
+      - shadow_mode_report
+      - rollback_test
+      - intervention_dashboard
+      - policy_signoff
+    accountable_roles:
+      - role.client.policy-owner
+      - role.consulting.evaluation-lead
+    exit_criteria:
+      - approved A2/A3 subset
+      - exception queue staffed
+
+client_dependencies:
+  - version: "1"
+    dependency_id: dep.crm-access
+    system: CRM
+    owner: role.client.system-owner
+    access_state: ready
+    criticality: critical
+    blockers: []
+    failure_modes: [missing_account_context, stale_data]
+  - version: "1"
+    dependency_id: dep.kb-corpus
+    system: Knowledge Base
+    owner: role.client.knowledge-owner
+    access_state: provisioning
+    criticality: high
+    blockers: [metadata_cleanup]
+    failure_modes: [stale_articles, low_citation_coverage]

--- a/examples/kmass-metrics-v1.yaml
+++ b/examples/kmass-metrics-v1.yaml
@@ -1,0 +1,11 @@
+metric_id: TAB.TEXT.GRAN
+figure_row: Textual Granularity
+metric_type: Outcome
+unit: Top-1 accuracy
+phase_targets:
+  - doc
+  - para
+  - sentence
+measurement_protocol: Exact match against labeled target set
+acceptable_error_margin: 10%
+evidence_artifact: labeled-query-set

--- a/examples/metadata-remediation-red-yellow.yaml
+++ b/examples/metadata-remediation-red-yellow.yaml
@@ -19,7 +19,7 @@ metadata_contact_assignment:
   contact_role: metadata_focal
   email: focal@example.com
   engagement_status: yellow
-  last_verified: 2026-04-10T10:00:00Z
+  last_verified: "2026-04-10T10:00:00Z"
   metadata_focal: focal-a
   intro_session_attended: true
 
@@ -32,7 +32,7 @@ metadata_completeness_evaluation:
   column_count: 120
   technical_metadata_coverage: 0.91
   business_metadata_coverage: 0.22
-  evaluation_timestamp: 2026-04-10T10:10:00Z
+  evaluation_timestamp: "2026-04-10T10:10:00Z"
   notes: Business term assignment coverage is below target and requires remediation.
 
 metadata_inconsistency_finding:
@@ -55,7 +55,7 @@ metadata_escalation_event:
   owner_role: metadata_operations_lead
   status: open
   severity: high
-  created_at: 2026-04-10T11:00:00Z
+  created_at: "2026-04-10T11:00:00Z"
   notes: Escalate due to low engagement signal and unresolved business metadata gap.
 
 metadata_sla_policy:

--- a/examples/metadata-remediation-red-yellow.yaml
+++ b/examples/metadata-remediation-red-yellow.yaml
@@ -1,0 +1,72 @@
+kmass_metric:
+  version: "1"
+  metric_id: TAB.TEXT.GRAN
+  figure_row: Textual Granularity
+  metric_type: outcome
+  unit: Top-1 accuracy
+  phase_targets:
+    - 80%@doc
+    - 80%@para
+    - 80%@sentence
+  measurement_protocol: Exact match against labeled target set with minimum sample of 30 queries per phase.
+  acceptable_error_margin: 10%
+  evidence_artifact: labeled-query-set-and-retrieval-logs
+
+metadata_contact_assignment:
+  version: "1"
+  artifact_id: artifact.customer.support.kb
+  contact_name: Metadata Focal A
+  contact_role: metadata_focal
+  email: focal@example.com
+  engagement_status: yellow
+  last_verified: 2026-04-10T10:00:00Z
+  metadata_focal: focal-a
+  intro_session_attended: true
+
+metadata_completeness_evaluation:
+  version: "1"
+  artifact_id: artifact.customer.support.kb
+  status: red
+  tmd_present: true
+  bmd_present: false
+  column_count: 120
+  technical_metadata_coverage: 0.91
+  business_metadata_coverage: 0.22
+  evaluation_timestamp: 2026-04-10T10:10:00Z
+  notes: Business term assignment coverage is below target and requires remediation.
+
+metadata_inconsistency_finding:
+  version: "1"
+  finding_id: finding.customer.support.kb.contact-sync
+  artifact_id: artifact.customer.support.kb
+  finding_class: metadata_contact_inconsistency
+  severity: high
+  owner_role: metadata_operations
+  status: open
+  jira_issue_key: MCDQ-9999
+  source_report: metadata_contacts_inconsistencies.xlsx
+  notes: Contact assignment in registry appears stale and requires revalidation.
+
+metadata_escalation_event:
+  version: "1"
+  escalation_id: esc.customer.support.kb.01
+  artifact_id: artifact.customer.support.kb
+  trigger_reason: yellow engagement plus breached response cadence on red completeness status
+  owner_role: metadata_operations_lead
+  status: open
+  severity: high
+  created_at: 2026-04-10T11:00:00Z
+  notes: Escalate due to low engagement signal and unresolved business metadata gap.
+
+metadata_sla_policy:
+  version: "1"
+  policy_id: sla.metadata.high
+  severity: high
+  response_sla: 2 business days
+  remediation_sla: 1 sprint
+  required_closure_evidence:
+    - owner-confirmation
+    - source-update-proof
+    - report-revalidation
+  escalation_trigger: missed response SLA or repeated reopen on high severity finding
+  notes: High severity metadata issues must be visible in sprint planning and gate evidence.

--- a/requirements-contracts.txt
+++ b/requirements-contracts.txt
@@ -1,0 +1,2 @@
+jsonschema==4.23.0
+pyyaml==6.0.2

--- a/schemas/autonomy-envelope.schema.json
+++ b/schemas/autonomy-envelope.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/autonomy-envelope.schema.json",
+  "title": "AutonomyEnvelope",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "workflow_id",
+    "owners",
+    "actions"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "workflow_id": { "type": "string" },
+    "owners": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["business_owner", "policy_owner", "operator_owner"],
+      "properties": {
+        "business_owner": { "type": "string" },
+        "policy_owner": { "type": "string" },
+        "operator_owner": { "type": "string" }
+      }
+    },
+    "actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "description",
+          "class",
+          "mode",
+          "reversible",
+          "requires_human_approval"
+        ],
+        "properties": {
+          "id": { "type": "string" },
+          "description": { "type": "string" },
+          "class": {
+            "type": "string",
+            "enum": ["A0", "A1", "A2", "A3", "A4"]
+          },
+          "mode": {
+            "type": "string",
+            "enum": ["observe", "draft", "approval_gated", "policy_bounded_auto", "human_only"]
+          },
+          "reversible": { "type": "boolean" },
+          "requires_human_approval": { "type": "boolean" },
+          "rollback_required": { "type": "boolean", "default": false },
+          "evidence_required": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "prohibited": { "type": "boolean", "default": false }
+        },
+        "allOf": [
+          {
+            "if": { "properties": { "class": { "const": "A4" } } },
+            "then": {
+              "properties": {
+                "mode": { "const": "human_only" },
+                "requires_human_approval": { "const": true }
+              }
+            }
+          },
+          {
+            "if": { "properties": { "class": { "const": "A3" } } },
+            "then": {
+              "properties": {
+                "reversible": { "const": true },
+                "rollback_required": { "const": true }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/schemas/autonomy-envelope.schema.json
+++ b/schemas/autonomy-envelope.schema.json
@@ -70,6 +70,7 @@
           {
             "if": { "properties": { "class": { "const": "A3" } } },
             "then": {
+              "required": ["rollback_required"],
               "properties": {
                 "reversible": { "const": true },
                 "rollback_required": { "const": true }

--- a/schemas/board-item.schema.json
+++ b/schemas/board-item.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/board-item.schema.json",
+  "title": "BoardItem",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "item_id",
+    "item_type",
+    "linked_engagement",
+    "linked_control_loop",
+    "current_gate",
+    "owner",
+    "priority"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "item_id": { "type": "string" },
+    "item_type": {
+      "type": "string",
+      "enum": ["engagement", "dependency", "exception", "gate_review", "reusable_asset", "risk", "delivery_work"]
+    },
+    "linked_engagement": { "type": "string" },
+    "linked_control_loop": { "type": "string" },
+    "current_gate": { "type": "string" },
+    "owner": { "type": "string" },
+    "priority": {
+      "type": "string",
+      "enum": ["P0", "P1", "P2", "P3"]
+    },
+    "blocked": { "type": "boolean", "default": false },
+    "evidence_links": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/schemas/bounty-program-policy.schema.json
+++ b/schemas/bounty-program-policy.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/bounty-program-policy.schema.json",
+  "title": "BountyProgramPolicy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "policy_id",
+    "name",
+    "service_offer_id",
+    "allowed_reward_signals",
+    "prohibited_reward_signals",
+    "gate_requirements",
+    "required_approver_role",
+    "requires_evidence_validation",
+    "requires_gate_approval"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "policy_id": { "type": "string" },
+    "name": { "type": "string" },
+    "service_offer_id": { "type": "string" },
+    "engagement_id": { "type": "string" },
+    "allowed_reward_signals": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "prohibited_reward_signals": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "gate_requirements": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "required_approver_role": { "type": "string" },
+    "payout_ceiling_amount": { "type": "number", "minimum": 0 },
+    "currency": { "type": "string" },
+    "requires_evidence_validation": { "type": "boolean" },
+    "requires_gate_approval": { "type": "boolean" },
+    "notes": { "type": "string" }
+  }
+}

--- a/schemas/client-dependency.schema.json
+++ b/schemas/client-dependency.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/client-dependency.schema.json",
+  "title": "ClientDependency",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "dependency_id",
+    "system",
+    "owner",
+    "access_state",
+    "criticality"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "dependency_id": { "type": "string" },
+    "system": { "type": "string" },
+    "owner": { "type": "string" },
+    "access_state": {
+      "type": "string",
+      "enum": ["not_requested", "requested", "provisioning", "ready", "blocked"]
+    },
+    "criticality": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"]
+    },
+    "blockers": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "due_date": {
+      "type": "string",
+      "format": "date"
+    },
+    "failure_modes": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "notes": { "type": "string" }
+  }
+}

--- a/schemas/control-loop.schema.json
+++ b/schemas/control-loop.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/control-loop.schema.json",
+  "title": "ControlLoop",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "control_loop_id",
+    "trigger",
+    "context_sources",
+    "allowed_tools",
+    "action_classes",
+    "approval_rule",
+    "exception_route",
+    "emitted_evidence",
+    "target_kpis"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "control_loop_id": { "type": "string" },
+    "trigger": { "type": "string" },
+    "context_sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "allowed_tools": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "action_classes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": ["A0", "A1", "A2", "A3", "A4"]
+      }
+    },
+    "approval_rule": { "type": "string" },
+    "exception_route": { "type": "string" },
+    "emitted_evidence": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "target_kpis": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/schemas/customer-success-review.schema.json
+++ b/schemas/customer-success-review.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/customer-success-review.schema.json",
+  "title": "CustomerSuccessReview",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "review_id",
+    "review_period",
+    "kpi_movement",
+    "intervention_summary",
+    "trust_signal"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "review_id": { "type": "string" },
+    "review_period": { "type": "string" },
+    "kpi_movement": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "intervention_summary": { "type": "string" },
+    "trust_signal": { "type": "string" },
+    "proposed_scope_changes": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "proposed_autonomy_changes": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/schemas/delivery-gate.schema.json
+++ b/schemas/delivery-gate.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/delivery-gate.schema.json",
+  "title": "DeliveryGate",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "gate_id",
+    "name",
+    "required_maturity",
+    "required_evidence",
+    "accountable_roles"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "gate_id": { "type": "string" },
+    "name": { "type": "string" },
+    "required_maturity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requirements",
+        "dependencies",
+        "knowledge",
+        "evaluation",
+        "governance"
+      ],
+      "properties": {
+        "requirements": { "type": "integer", "minimum": 0, "maximum": 4 },
+        "dependencies": { "type": "integer", "minimum": 0, "maximum": 4 },
+        "knowledge": { "type": "integer", "minimum": 0, "maximum": 4 },
+        "evaluation": { "type": "integer", "minimum": 0, "maximum": 4 },
+        "governance": { "type": "integer", "minimum": 0, "maximum": 4 }
+      }
+    },
+    "required_evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "accountable_roles": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "exit_criteria": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/schemas/engagement.schema.json
+++ b/schemas/engagement.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/engagement.schema.json",
+  "title": "Engagement",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "engagement_id",
+    "service_offer_id",
+    "sponsor",
+    "process_owner",
+    "system_owner",
+    "data_owner",
+    "policy_owner",
+    "operator_owner",
+    "target_workflow",
+    "current_gate",
+    "current_autonomy_classes",
+    "kpi_baseline"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "engagement_id": { "type": "string" },
+    "service_offer_id": { "type": "string" },
+    "sponsor": { "type": "string" },
+    "process_owner": { "type": "string" },
+    "system_owner": { "type": "string" },
+    "data_owner": { "type": "string" },
+    "policy_owner": { "type": "string" },
+    "operator_owner": { "type": "string" },
+    "target_workflow": { "type": "string" },
+    "current_gate": { "type": "string" },
+    "current_autonomy_classes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "enum": ["A0", "A1", "A2", "A3", "A4"] }
+    },
+    "kpi_baseline": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "notes": { "type": "string" }
+  }
+}

--- a/schemas/escrow-reference.schema.json
+++ b/schemas/escrow-reference.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/escrow-reference.schema.json",
+  "title": "EscrowReference",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "escrow_reference_id",
+    "instrument_type",
+    "currency",
+    "amount",
+    "status"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "escrow_reference_id": { "type": "string" },
+    "instrument_type": {
+      "type": "string",
+      "enum": ["fiat", "stablecoin", "token", "internal_ledger", "external_escrow"]
+    },
+    "currency": { "type": "string" },
+    "amount": { "type": "number", "minimum": 0 },
+    "external_reference": { "type": "string" },
+    "status": {
+      "type": "string",
+      "enum": ["reserved", "released", "cancelled", "settled"]
+    },
+    "notes": { "type": "string" }
+  }
+}

--- a/schemas/exception-class.schema.json
+++ b/schemas/exception-class.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/exception-class.schema.json",
+  "title": "ExceptionClass",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "exception_id",
+    "severity",
+    "trigger_condition",
+    "human_owner",
+    "resolution_target_hours"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "exception_id": { "type": "string" },
+    "severity": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"]
+    },
+    "trigger_condition": { "type": "string" },
+    "human_owner": { "type": "string" },
+    "resolution_target_hours": { "type": "number", "minimum": 0 },
+    "stop_work": { "type": "boolean", "default": false },
+    "rollback_considered": { "type": "boolean", "default": false },
+    "notes": { "type": "string" }
+  }
+}

--- a/schemas/gate-review.schema.json
+++ b/schemas/gate-review.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/gate-review.schema.json",
+  "title": "GateReview",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "review_id",
+    "gate_id",
+    "engagement_id",
+    "current_action_classes",
+    "proposed_change",
+    "maturity_scores",
+    "decision"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "review_id": { "type": "string" },
+    "gate_id": { "type": "string" },
+    "engagement_id": { "type": "string" },
+    "current_action_classes": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["A0", "A1", "A2", "A3", "A4"] }
+    },
+    "proposed_change": { "type": "string" },
+    "maturity_scores": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requirements", "dependencies", "knowledge", "evaluation", "governance"],
+      "properties": {
+        "requirements": { "type": "integer", "minimum": 0, "maximum": 4 },
+        "dependencies": { "type": "integer", "minimum": 0, "maximum": 4 },
+        "knowledge": { "type": "integer", "minimum": 0, "maximum": 4 },
+        "evaluation": { "type": "integer", "minimum": 0, "maximum": 4 },
+        "governance": { "type": "integer", "minimum": 0, "maximum": 4 }
+      }
+    },
+    "decision": { "type": "string", "enum": ["approved", "approved_with_constraints", "not_approved"] },
+    "follow_up_actions": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/schemas/kmass-metric.schema.json
+++ b/schemas/kmass-metric.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/kmass-metric.schema.json",
+  "title": "KMASSMetric",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "metric_id",
+    "metric_type",
+    "unit",
+    "phase_targets",
+    "measurement_protocol",
+    "acceptable_error_margin",
+    "evidence_artifact"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "metric_id": { "type": "string" },
+    "figure_row": { "type": "string" },
+    "metric_type": { "type": "string", "enum": ["outcome", "capacity", "friction", "composite"] },
+    "unit": { "type": "string" },
+    "phase_targets": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "measurement_protocol": { "type": "string" },
+    "acceptable_error_margin": { "type": "string" },
+    "evidence_artifact": { "type": "string" }
+  }
+}

--- a/schemas/metadata-completeness-evaluation.schema.json
+++ b/schemas/metadata-completeness-evaluation.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/metadata-completeness-evaluation.schema.json",
+  "title": "MetadataCompletenessEvaluation",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "artifact_id",
+    "status",
+    "tmd_present",
+    "bmd_present",
+    "evaluation_timestamp"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "artifact_id": { "type": "string" },
+    "status": { "type": "string", "enum": ["red", "yellow", "green"] },
+    "tmd_present": { "type": "boolean" },
+    "bmd_present": { "type": "boolean" },
+    "column_count": { "type": "integer", "minimum": 0 },
+    "technical_metadata_coverage": { "type": "number", "minimum": 0, "maximum": 1 },
+    "business_metadata_coverage": { "type": "number", "minimum": 0, "maximum": 1 },
+    "evaluation_timestamp": { "type": "string", "format": "date-time" },
+    "notes": { "type": "string" }
+  }
+}

--- a/schemas/metadata-contact-assignment.schema.json
+++ b/schemas/metadata-contact-assignment.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/metadata-contact-assignment.schema.json",
+  "title": "MetadataContactAssignment",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "artifact_id",
+    "contact_name",
+    "contact_role",
+    "email",
+    "engagement_status"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "artifact_id": { "type": "string" },
+    "contact_name": { "type": "string" },
+    "contact_role": { "type": "string" },
+    "email": { "type": "string", "format": "email" },
+    "engagement_status": { "type": "string", "enum": ["red", "yellow", "green"] },
+    "last_verified": { "type": "string", "format": "date-time" },
+    "metadata_focal": { "type": "string" },
+    "intro_session_attended": { "type": "boolean" }
+  }
+}

--- a/schemas/metadata-escalation-event.schema.json
+++ b/schemas/metadata-escalation-event.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/metadata-escalation-event.schema.json",
+  "title": "MetadataEscalationEvent",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "escalation_id",
+    "artifact_id",
+    "trigger_reason",
+    "owner_role",
+    "status",
+    "created_at"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "escalation_id": { "type": "string" },
+    "artifact_id": { "type": "string" },
+    "trigger_reason": { "type": "string" },
+    "owner_role": { "type": "string" },
+    "status": { "type": "string", "enum": ["open", "acknowledged", "resolved", "dismissed"] },
+    "severity": { "type": "string", "enum": ["critical", "high", "medium", "low"] },
+    "created_at": { "type": "string", "format": "date-time" },
+    "resolved_at": { "type": "string", "format": "date-time" },
+    "notes": { "type": "string" }
+  }
+}

--- a/schemas/metadata-inconsistency-finding.schema.json
+++ b/schemas/metadata-inconsistency-finding.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/metadata-inconsistency-finding.schema.json",
+  "title": "MetadataInconsistencyFinding",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "finding_id",
+    "artifact_id",
+    "finding_class",
+    "severity",
+    "owner_role",
+    "status"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "finding_id": { "type": "string" },
+    "artifact_id": { "type": "string" },
+    "finding_class": {
+      "type": "string",
+      "enum": [
+        "tabs_without_columns",
+        "schema_without_app",
+        "schema_without_table",
+        "schema_without_table_oos",
+        "schemas_missing_in_igc",
+        "out_of_sync_column",
+        "metadata_contact_inconsistency",
+        "data_artifact_inconsistency",
+        "glossary_quality_issue",
+        "btnr_candidate"
+      ]
+    },
+    "severity": { "type": "string", "enum": ["critical", "high", "medium", "low"] },
+    "owner_role": { "type": "string" },
+    "status": { "type": "string", "enum": ["open", "in_progress", "blocked", "resolved", "ignored"] },
+    "jira_issue_key": { "type": "string" },
+    "source_report": { "type": "string" },
+    "notes": { "type": "string" }
+  }
+}

--- a/schemas/metadata-sla-policy.schema.json
+++ b/schemas/metadata-sla-policy.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/metadata-sla-policy.schema.json",
+  "title": "MetadataSLAPolicy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "policy_id",
+    "severity",
+    "response_sla",
+    "remediation_sla",
+    "required_closure_evidence"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "policy_id": { "type": "string" },
+    "severity": { "type": "string", "enum": ["critical", "high", "medium", "low"] },
+    "response_sla": { "type": "string" },
+    "remediation_sla": { "type": "string" },
+    "required_closure_evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "escalation_trigger": { "type": "string" },
+    "notes": { "type": "string" }
+  }
+}

--- a/schemas/payout-decision.schema.json
+++ b/schemas/payout-decision.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/payout-decision.schema.json",
+  "title": "PayoutDecision",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "payout_decision_id",
+    "engagement_id",
+    "gate_id",
+    "status",
+    "decision_owner",
+    "evidence_links"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "payout_decision_id": { "type": "string" },
+    "engagement_id": { "type": "string" },
+    "gate_id": { "type": "string" },
+    "status": {
+      "type": "string",
+      "enum": ["pending", "approved", "blocked", "rejected", "paid"]
+    },
+    "decision_owner": { "type": "string" },
+    "evidence_links": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "reusable_asset_ids": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "exception_ids": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "escrow_reference_id": { "type": "string" },
+    "amount": { "type": "number", "minimum": 0 },
+    "currency": { "type": "string" },
+    "rationale": { "type": "string" }
+  }
+}

--- a/schemas/reusable-asset.schema.json
+++ b/schemas/reusable-asset.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/reusable-asset.schema.json",
+  "title": "ReusableAsset",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "asset_id",
+    "asset_type",
+    "owning_group",
+    "source_engagements",
+    "readiness_status"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "asset_id": { "type": "string" },
+    "asset_type": {
+      "type": "string",
+      "enum": ["playbook", "template", "schema", "automation", "pattern", "training"]
+    },
+    "owning_group": { "type": "string" },
+    "source_engagements": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "evidence_of_reuse_value": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "readiness_status": {
+      "type": "string",
+      "enum": ["draft", "review", "approved", "retired"]
+    }
+  }
+}

--- a/schemas/service-catalog-entry.schema.json
+++ b/schemas/service-catalog-entry.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/service-catalog-entry.schema.json",
+  "title": "ServiceCatalogEntry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "service_id",
+    "service_name",
+    "function_area",
+    "service_area",
+    "owners",
+    "success_kpis"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "service_id": { "type": "string" },
+    "service_name": { "type": "string" },
+    "function_area": { "type": "string" },
+    "service_area": { "type": "string" },
+    "owners": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "success_kpis": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "linked_delivery_gates": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "linked_reusable_assets": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "notes": { "type": "string" }
+  }
+}

--- a/schemas/service-level-agreement.schema.json
+++ b/schemas/service-level-agreement.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/service-level-agreement.schema.json",
+  "title": "ServiceLevelAgreement",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "sla_id",
+    "service_id",
+    "service_name",
+    "response_targets",
+    "resolution_targets",
+    "measurement_method",
+    "evidence_requirements"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "sla_id": { "type": "string" },
+    "service_id": { "type": "string" },
+    "service_name": { "type": "string" },
+    "response_targets": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "resolution_targets": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "measurement_method": { "type": "string" },
+    "evidence_requirements": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "escalation_policy_id": { "type": "string" },
+    "notes": { "type": "string" }
+  }
+}

--- a/schemas/service-offer.schema.json
+++ b/schemas/service-offer.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.invalid/schemas/service-offer.schema.json",
+  "title": "ServiceOffer",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "offer_id",
+    "name",
+    "buyer_problem",
+    "stages",
+    "excluded_actions",
+    "managed_service_follow_on"
+  ],
+  "properties": {
+    "version": { "type": "string" },
+    "offer_id": { "type": "string" },
+    "name": { "type": "string" },
+    "buyer_problem": { "type": "string" },
+    "stages": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "excluded_actions": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "acceptance_model": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "managed_service_follow_on": { "type": "boolean" },
+    "target_kpis": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/scripts/validate_agentic_contracts.py
+++ b/scripts/validate_agentic_contracts.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 import yaml
-from jsonschema import Draft202012Validator
+from jsonschema import Draft202012Validator, FormatChecker
 
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_DIR = ROOT / "schemas"
@@ -44,7 +44,7 @@ def validate_one(validator: Draft202012Validator, obj: object, label: str) -> li
 
 def main() -> int:
     validators = {
-        name: Draft202012Validator(load_json(SCHEMA_DIR / schema_file))
+        name: Draft202012Validator(load_json(SCHEMA_DIR / schema_file), format_checker=FormatChecker())
         for name, schema_file in BUNDLE_SPEC.items()
     }
 
@@ -57,45 +57,46 @@ def main() -> int:
 
     for bundle_path in bundle_paths:
         bundle = load_yaml(bundle_path)
+        bundle_failures: list[str] = []
         for section_name, schema_file in BUNDLE_SPEC.items():
             if section_name not in bundle:
-                failures.append(f"{bundle_path.name}: missing section '{section_name}'")
+                bundle_failures.append(f"{bundle_path.name}: missing section '{section_name}'")
                 continue
             payload = bundle[section_name]
             validator = validators[section_name]
             if isinstance(payload, list):
                 for idx, item in enumerate(payload):
-                    failures.extend(validate_one(validator, item, f"{bundle_path.name}:{section_name}[{idx}]"))
+                    bundle_failures.extend(validate_one(validator, item, f"{bundle_path.name}:{section_name}[{idx}]"))
             else:
-                failures.extend(validate_one(validator, payload, f"{bundle_path.name}:{section_name}"))
+                bundle_failures.extend(validate_one(validator, payload, f"{bundle_path.name}:{section_name}"))
 
-        if failures:
-            continue
+        if not bundle_failures:
+            gate_ids = {g["gate_id"] for g in bundle["delivery_gates"]}
+            known_action_classes = {a["class"] for a in bundle["autonomy_envelope"]["actions"]}
+            control_loop_id = bundle["control_loop"]["control_loop_id"]
 
-        gate_ids = {g["gate_id"] for g in bundle["delivery_gates"]}
-        known_action_classes = {a["class"] for a in bundle["autonomy_envelope"]["actions"]}
-        control_loop_id = bundle["control_loop"]["control_loop_id"]
-
-        if bundle["gate_review"]["gate_id"] not in gate_ids:
-            failures.append(
-                f"{bundle_path.name}: gate_review.gate_id '{bundle['gate_review']['gate_id']}' not found in delivery_gates"
-            )
-
-        for item in bundle["board_items"]:
-            if item["current_gate"] not in gate_ids:
-                failures.append(
-                    f"{bundle_path.name}: board item '{item['item_id']}' references unknown gate '{item['current_gate']}'"
-                )
-            if item["linked_control_loop"] != control_loop_id:
-                failures.append(
-                    f"{bundle_path.name}: board item '{item['item_id']}' linked_control_loop must match bundle control loop"
+            if bundle["gate_review"]["gate_id"] not in gate_ids:
+                bundle_failures.append(
+                    f"{bundle_path.name}: gate_review.gate_id '{bundle['gate_review']['gate_id']}' not found in delivery_gates"
                 )
 
-        for action_class in bundle["gate_review"]["current_action_classes"]:
-            if action_class not in known_action_classes:
-                failures.append(
-                    f"{bundle_path.name}: gate review references unknown action class '{action_class}'"
-                )
+            for item in bundle["board_items"]:
+                if item["current_gate"] not in gate_ids:
+                    bundle_failures.append(
+                        f"{bundle_path.name}: board item '{item['item_id']}' references unknown gate '{item['current_gate']}'"
+                    )
+                if item["linked_control_loop"] != control_loop_id:
+                    bundle_failures.append(
+                        f"{bundle_path.name}: board item '{item['item_id']}' linked_control_loop must match bundle control loop"
+                    )
+
+            for action_class in bundle["gate_review"]["current_action_classes"]:
+                if action_class not in known_action_classes:
+                    bundle_failures.append(
+                        f"{bundle_path.name}: gate review references unknown action class '{action_class}'"
+                    )
+
+        failures.extend(bundle_failures)
 
     if failures:
         for failure in failures:

--- a/scripts/validate_agentic_contracts.py
+++ b/scripts/validate_agentic_contracts.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_DIR = ROOT / "schemas"
+EXAMPLE_DIR = ROOT / "examples"
+
+BUNDLE_SPEC = {
+    "service_offer": "service-offer.schema.json",
+    "control_loop": "control-loop.schema.json",
+    "autonomy_envelope": "autonomy-envelope.schema.json",
+    "delivery_gates": "delivery-gate.schema.json",
+    "client_dependencies": "client-dependency.schema.json",
+    "exception_classes": "exception-class.schema.json",
+    "board_items": "board-item.schema.json",
+    "reusable_assets": "reusable-asset.schema.json",
+    "customer_success_review": "customer-success-review.schema.json",
+    "gate_review": "gate-review.schema.json",
+}
+
+
+def load_yaml(path: Path):
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate_one(validator: Draft202012Validator, obj: object, label: str) -> list[str]:
+    errors = []
+    for err in sorted(validator.iter_errors(obj), key=lambda e: list(e.path)):
+        path = "/".join(str(p) for p in err.path)
+        errors.append(f"{label}: {path or '<root>'}: {err.message}")
+    return errors
+
+
+def main() -> int:
+    validators = {
+        name: Draft202012Validator(load_json(SCHEMA_DIR / schema_file))
+        for name, schema_file in BUNDLE_SPEC.items()
+    }
+
+    bundle_paths = sorted(EXAMPLE_DIR.glob("*.bundle.yaml"))
+    if not bundle_paths:
+        print("[FAIL] no *.bundle.yaml examples found", file=sys.stderr)
+        return 2
+
+    failures: list[str] = []
+
+    for bundle_path in bundle_paths:
+        bundle = load_yaml(bundle_path)
+        for section_name, schema_file in BUNDLE_SPEC.items():
+            if section_name not in bundle:
+                failures.append(f"{bundle_path.name}: missing section '{section_name}'")
+                continue
+            payload = bundle[section_name]
+            validator = validators[section_name]
+            if isinstance(payload, list):
+                for idx, item in enumerate(payload):
+                    failures.extend(validate_one(validator, item, f"{bundle_path.name}:{section_name}[{idx}]"))
+            else:
+                failures.extend(validate_one(validator, payload, f"{bundle_path.name}:{section_name}"))
+
+        if failures:
+            continue
+
+        gate_ids = {g["gate_id"] for g in bundle["delivery_gates"]}
+        known_action_classes = {a["class"] for a in bundle["autonomy_envelope"]["actions"]}
+        control_loop_id = bundle["control_loop"]["control_loop_id"]
+
+        if bundle["gate_review"]["gate_id"] not in gate_ids:
+            failures.append(
+                f"{bundle_path.name}: gate_review.gate_id '{bundle['gate_review']['gate_id']}' not found in delivery_gates"
+            )
+
+        for item in bundle["board_items"]:
+            if item["current_gate"] not in gate_ids:
+                failures.append(
+                    f"{bundle_path.name}: board item '{item['item_id']}' references unknown gate '{item['current_gate']}'"
+                )
+            if item["linked_control_loop"] != control_loop_id:
+                failures.append(
+                    f"{bundle_path.name}: board item '{item['item_id']}' linked_control_loop must match bundle control loop"
+                )
+
+        for action_class in bundle["gate_review"]["current_action_classes"]:
+            if action_class not in known_action_classes:
+                failures.append(
+                    f"{bundle_path.name}: gate review references unknown action class '{action_class}'"
+                )
+
+    if failures:
+        for failure in failures:
+            print(f"[FAIL] {failure}", file=sys.stderr)
+        return 1
+
+    print("[OK] agentic contract bundles validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_all_contracts.py
+++ b/scripts/validate_all_contracts.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+CHECKS = [
+    [sys.executable, str(ROOT / "scripts" / "validate_agentic_contracts.py")],
+    [sys.executable, str(ROOT / "scripts" / "validate_engagement_objects.py")],
+]
+
+
+def main() -> int:
+    failures = 0
+    for cmd in CHECKS:
+        result = subprocess.run(cmd, check=False)
+        if result.returncode != 0:
+            failures += 1
+    if failures:
+        return 1
+    print("[OK] all contract validations passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_engagement_objects.py
+++ b/scripts/validate_engagement_objects.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "engagement.schema.json"
+EXAMPLE_DIR = ROOT / "examples"
+
+
+def load_yaml(path: Path):
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    validator = Draft202012Validator(load_json(SCHEMA))
+    paths = sorted(EXAMPLE_DIR.glob("*.engagement.yaml"))
+    if not paths:
+        print("[FAIL] no *.engagement.yaml examples found", file=sys.stderr)
+        return 2
+
+    failures: list[str] = []
+    for path in paths:
+      obj = load_yaml(path)
+      for err in sorted(validator.iter_errors(obj), key=lambda e: list(e.path)):
+          field_path = "/".join(str(p) for p in err.path)
+          failures.append(f"{path.name}: {field_path or '<root>'}: {err.message}")
+
+    if failures:
+        for failure in failures:
+            print(f"[FAIL] {failure}", file=sys.stderr)
+        return 1
+
+    print("[OK] engagement objects validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_engagement_objects.py
+++ b/scripts/validate_engagement_objects.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 import yaml
-from jsonschema import Draft202012Validator
+from jsonschema import Draft202012Validator, FormatChecker
 
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMA = ROOT / "schemas" / "engagement.schema.json"
@@ -22,7 +22,7 @@ def load_json(path: Path):
 
 
 def main() -> int:
-    validator = Draft202012Validator(load_json(SCHEMA))
+    validator = Draft202012Validator(load_json(SCHEMA), format_checker=FormatChecker())
     paths = sorted(EXAMPLE_DIR.glob("*.engagement.yaml"))
     if not paths:
         print("[FAIL] no *.engagement.yaml examples found", file=sys.stderr)
@@ -30,10 +30,10 @@ def main() -> int:
 
     failures: list[str] = []
     for path in paths:
-      obj = load_yaml(path)
-      for err in sorted(validator.iter_errors(obj), key=lambda e: list(e.path)):
-          field_path = "/".join(str(p) for p in err.path)
-          failures.append(f"{path.name}: {field_path or '<root>'}: {err.message}")
+        obj = load_yaml(path)
+        for err in sorted(validator.iter_errors(obj), key=lambda e: list(e.path)):
+            field_path = "/".join(str(p) for p in err.path)
+            failures.append(f"{path.name}: {field_path or '<root>'}: {err.message}")
 
     if failures:
         for failure in failures:

--- a/scripts/validate_incentive_policy.py
+++ b/scripts/validate_incentive_policy.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "bounty-program-policy.schema.json"
+EXAMPLE_DIR = ROOT / "examples"
+
+
+def load_yaml(path: Path):
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    validator = Draft202012Validator(load_json(SCHEMA))
+    paths = sorted(EXAMPLE_DIR.glob("*.bounty-policy.yaml"))
+    if not paths:
+        print("[FAIL] no *.bounty-policy.yaml examples found", file=sys.stderr)
+        return 2
+
+    failures: list[str] = []
+    for path in paths:
+        policy = load_yaml(path)
+        prefix = path.name.removesuffix(".bounty-policy.yaml")
+        bundle_path = EXAMPLE_DIR / f"{prefix}.bundle.yaml"
+        engagement_path = EXAMPLE_DIR / f"{prefix}.engagement.yaml"
+
+        for err in sorted(validator.iter_errors(policy), key=lambda e: list(e.path)):
+            field_path = "/".join(str(p) for p in err.path)
+            failures.append(f"{path.name}: {field_path or '<root>'}: {err.message}")
+
+        if failures:
+            continue
+
+        if not bundle_path.exists():
+            failures.append(f"{path.name}: missing sibling bundle example {bundle_path.name}")
+            continue
+        if not engagement_path.exists():
+            failures.append(f"{path.name}: missing sibling engagement example {engagement_path.name}")
+            continue
+
+        bundle = load_yaml(bundle_path)
+        engagement = load_yaml(engagement_path)
+        gate_ids = {g["gate_id"] for g in bundle.get("delivery_gates", [])}
+        service_offer_id = bundle.get("service_offer", {}).get("offer_id")
+        engagement_id = engagement.get("engagement_id")
+
+        if policy["service_offer_id"] != service_offer_id:
+            failures.append(
+                f"{path.name}: service_offer_id '{policy['service_offer_id']}' does not match bundle offer_id '{service_offer_id}'"
+            )
+        if policy.get("engagement_id") and policy["engagement_id"] != engagement_id:
+            failures.append(
+                f"{path.name}: engagement_id '{policy['engagement_id']}' does not match engagement example '{engagement_id}'"
+            )
+        for gate_id in policy.get("gate_requirements", []):
+            if gate_id not in gate_ids:
+                failures.append(f"{path.name}: unknown gate requirement '{gate_id}'")
+
+    if failures:
+        for failure in failures:
+            print(f"[FAIL] {failure}", file=sys.stderr)
+        return 1
+
+    print("[OK] incentive policies validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_metadata_operations.py
+++ b/scripts/validate_metadata_operations.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 import yaml
-from jsonschema import Draft202012Validator
+from jsonschema import Draft202012Validator, FormatChecker
 
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_DIR = ROOT / "schemas"
@@ -32,7 +32,7 @@ def load_json(path: Path):
 
 def main() -> int:
     validators = {
-        section: Draft202012Validator(load_json(SCHEMA_DIR / schema_name))
+        section: Draft202012Validator(load_json(SCHEMA_DIR / schema_name), format_checker=FormatChecker())
         for section, schema_name in SECTION_TO_SCHEMA.items()
     }
 

--- a/scripts/validate_metadata_operations.py
+++ b/scripts/validate_metadata_operations.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_DIR = ROOT / "schemas"
+EXAMPLE_DIR = ROOT / "examples"
+
+SECTION_TO_SCHEMA = {
+    "kmass_metric": "kmass-metric.schema.json",
+    "metadata_contact_assignment": "metadata-contact-assignment.schema.json",
+    "metadata_completeness_evaluation": "metadata-completeness-evaluation.schema.json",
+    "metadata_inconsistency_finding": "metadata-inconsistency-finding.schema.json",
+    "metadata_escalation_event": "metadata-escalation-event.schema.json",
+    "metadata_sla_policy": "metadata-sla-policy.schema.json",
+}
+
+
+def load_yaml(path: Path):
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    validators = {
+        section: Draft202012Validator(load_json(SCHEMA_DIR / schema_name))
+        for section, schema_name in SECTION_TO_SCHEMA.items()
+    }
+
+    paths = sorted(EXAMPLE_DIR.glob("metadata-remediation-*.yaml"))
+    if not paths:
+        print("[FAIL] no metadata remediation examples found", file=sys.stderr)
+        return 2
+
+    failures: list[str] = []
+
+    for path in paths:
+        payload = load_yaml(path)
+        for section, validator in validators.items():
+            if section not in payload:
+                failures.append(f"{path.name}: missing section '{section}'")
+                continue
+            obj = payload[section]
+            for err in sorted(validator.iter_errors(obj), key=lambda e: list(e.path)):
+                field_path = "/".join(str(p) for p in err.path)
+                failures.append(f"{path.name}:{section}:{field_path or '<root>'}: {err.message}")
+
+        if failures:
+            continue
+
+        artifact_id = payload["metadata_contact_assignment"]["artifact_id"]
+        if payload["metadata_completeness_evaluation"]["artifact_id"] != artifact_id:
+            failures.append(f"{path.name}: completeness artifact_id mismatch")
+        if payload["metadata_inconsistency_finding"]["artifact_id"] != artifact_id:
+            failures.append(f"{path.name}: inconsistency artifact_id mismatch")
+        if payload["metadata_escalation_event"]["artifact_id"] != artifact_id:
+            failures.append(f"{path.name}: escalation artifact_id mismatch")
+        if payload["metadata_escalation_event"]["severity"] != payload["metadata_sla_policy"]["severity"]:
+            failures.append(f"{path.name}: escalation severity must match SLA severity in this example")
+
+    if failures:
+        for failure in failures:
+            print(f"[FAIL] {failure}", file=sys.stderr)
+        return 1
+
+    print("[OK] metadata operations examples validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_payout_objects.py
+++ b/scripts/validate_payout_objects.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_DIR = ROOT / "schemas"
+EXAMPLE_DIR = ROOT / "examples"
+
+
+def load_yaml(path: Path):
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    payout_validator = Draft202012Validator(load_json(SCHEMA_DIR / "payout-decision.schema.json"))
+    escrow_validator = Draft202012Validator(load_json(SCHEMA_DIR / "escrow-reference.schema.json"))
+
+    paths = sorted(EXAMPLE_DIR.glob("*.payout.yaml"))
+    if not paths:
+        print("[FAIL] no *.payout.yaml examples found", file=sys.stderr)
+        return 2
+
+    failures: list[str] = []
+
+    for path in paths:
+        payload = load_yaml(path)
+        prefix = path.name.removesuffix(".payout.yaml")
+        bundle_path = EXAMPLE_DIR / f"{prefix}.bundle.yaml"
+        engagement_path = EXAMPLE_DIR / f"{prefix}.engagement.yaml"
+
+        if "payout_decision" not in payload:
+            failures.append(f"{path.name}: missing payout_decision")
+            continue
+        if "escrow_reference" not in payload:
+            failures.append(f"{path.name}: missing escrow_reference")
+            continue
+
+        payout = payload["payout_decision"]
+        escrow = payload["escrow_reference"]
+
+        for err in sorted(payout_validator.iter_errors(payout), key=lambda e: list(e.path)):
+            field_path = "/".join(str(p) for p in err.path)
+            failures.append(f"{path.name}:payout_decision:{field_path or '<root>'}: {err.message}")
+        for err in sorted(escrow_validator.iter_errors(escrow), key=lambda e: list(e.path)):
+            field_path = "/".join(str(p) for p in err.path)
+            failures.append(f"{path.name}:escrow_reference:{field_path or '<root>'}: {err.message}")
+
+        if failures:
+            continue
+
+        if not bundle_path.exists():
+            failures.append(f"{path.name}: missing sibling bundle example {bundle_path.name}")
+            continue
+        if not engagement_path.exists():
+            failures.append(f"{path.name}: missing sibling engagement example {engagement_path.name}")
+            continue
+
+        bundle = load_yaml(bundle_path)
+        engagement = load_yaml(engagement_path)
+
+        gate_ids = {g["gate_id"] for g in bundle.get("delivery_gates", [])}
+        reusable_asset_ids = {a["asset_id"] for a in bundle.get("reusable_assets", [])}
+        exception_ids = {e["exception_id"] for e in bundle.get("exception_classes", [])}
+        evidence_universe = set(bundle.get("control_loop", {}).get("emitted_evidence", []))
+        for gate in bundle.get("delivery_gates", []):
+            evidence_universe |= set(gate.get("required_evidence", []))
+        for item in bundle.get("board_items", []):
+            evidence_universe |= set(item.get("evidence_links", []))
+
+        if payout["engagement_id"] != engagement["engagement_id"]:
+            failures.append(
+                f"{path.name}: payout engagement_id '{payout['engagement_id']}' does not match engagement example '{engagement['engagement_id']}'"
+            )
+        if payout["gate_id"] not in gate_ids:
+            failures.append(f"{path.name}: unknown gate_id '{payout['gate_id']}'")
+        if payout.get("escrow_reference_id") != escrow["escrow_reference_id"]:
+            failures.append(f"{path.name}: escrow reference mismatch between payout decision and escrow object")
+
+        for asset_id in payout.get("reusable_asset_ids", []):
+            if asset_id not in reusable_asset_ids:
+                failures.append(f"{path.name}: unknown reusable_asset_id '{asset_id}'")
+        for exception_id in payout.get("exception_ids", []):
+            if exception_id not in exception_ids:
+                failures.append(f"{path.name}: unknown exception_id '{exception_id}'")
+        for evidence in payout.get("evidence_links", []):
+            if evidence not in evidence_universe:
+                failures.append(f"{path.name}: evidence link '{evidence}' not found in sibling bundle evidence universe")
+
+    if failures:
+        for failure in failures:
+            print(f"[FAIL] {failure}", file=sys.stderr)
+        return 1
+
+    print("[OK] payout and escrow objects validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_service_catalog_and_sla.py
+++ b/scripts/validate_service_catalog_and_sla.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_DIR = ROOT / "schemas"
+EXAMPLE_DIR = ROOT / "examples"
+
+
+def load_yaml(path: Path):
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    service_validator = Draft202012Validator(load_json(SCHEMA_DIR / "service-catalog-entry.schema.json"))
+    sla_validator = Draft202012Validator(load_json(SCHEMA_DIR / "service-level-agreement.schema.json"))
+
+    paths = sorted(EXAMPLE_DIR.glob("coc-service-catalog-and-sla.yaml"))
+    if not paths:
+        print("[FAIL] no service catalog + SLA examples found", file=sys.stderr)
+        return 2
+
+    failures: list[str] = []
+    for path in paths:
+        payload = load_yaml(path)
+        if "service_catalog_entry" not in payload:
+            failures.append(f"{path.name}: missing service_catalog_entry")
+            continue
+        if "service_level_agreement" not in payload:
+            failures.append(f"{path.name}: missing service_level_agreement")
+            continue
+
+        service = payload["service_catalog_entry"]
+        sla = payload["service_level_agreement"]
+
+        for err in sorted(service_validator.iter_errors(service), key=lambda e: list(e.path)):
+            field_path = "/".join(str(p) for p in err.path)
+            failures.append(f"{path.name}:service_catalog_entry:{field_path or '<root>'}: {err.message}")
+        for err in sorted(sla_validator.iter_errors(sla), key=lambda e: list(e.path)):
+            field_path = "/".join(str(p) for p in err.path)
+            failures.append(f"{path.name}:service_level_agreement:{field_path or '<root>'}: {err.message}")
+
+        if failures:
+            continue
+
+        if service["service_id"] != sla["service_id"]:
+            failures.append(f"{path.name}: service_id mismatch between service catalog entry and SLA")
+        if service["service_name"] != sla["service_name"]:
+            failures.append(f"{path.name}: service_name mismatch between service catalog entry and SLA")
+
+    if failures:
+        for failure in failures:
+            print(f"[FAIL] {failure}", file=sys.stderr)
+        return 1
+
+    print("[OK] service catalog and SLA examples validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Establish the first machine-readable contract layer for DelEx-OS agentic services.

## Adds

- automation contract docs index
- validation contract document
- autonomy-envelope schema
- delivery-gate schema
- client-dependency schema
- worked customer-success/support accelerator example

## Why

`delivery-excellence` now carries the human-readable canon. This PR makes `delivery-excellence-automation` the executable contract surface for the same model.

## Follow-up

- extend `scripts/validate_configs.py` or add a new validator to check schema conformance
- connect downstream consumers in `delivery-excellence-boards` and `delivery-excellence-innersource`
- later align `delivery-excellence-bounties` with gate/evidence completion rather than standalone scoring semantics
