### PR TITLE
ci: add Delivery Excellence validation suite

### DIFF
--- a/.github/workflows/validation-suite.yml
+++ b/.github/workflows/validation-suite.yml
@@ -1,0 +1,18 @@
+name: validation-suite
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+jobs:
+  validation-suite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --upgrade pip
+      - run: |
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          if [ -f requirements-contracts.txt ]; then pip install -r requirements-contracts.txt; fi
+      - run: python scripts/run_validation_suite.py

--- a/docs/validation-suite.md
+++ b/docs/validation-suite.md
@@ -1,0 +1,45 @@
+# Validation Suite
+
+## Purpose
+
+This document indexes the validation surfaces in `delivery-excellence-automation` and defines the single operator entrypoint.
+
+## Primary command
+
+```bash
+python scripts/run_validation_suite.py
+```
+
+The suite runner executes every known validator that exists in the repository and skips validators that are not present on a given branch.
+
+## Validation surfaces
+
+### Governance automation
+- `scripts/validate_configs.py`
+- validates group, RBAC, email, and calendar referential integrity
+
+### Agentic services contracts
+- `scripts/validate_all_contracts.py`
+- validates service-offer, engagement, control-loop, autonomy-envelope, gate, dependency, exception, board, reusable-asset, customer-success, and gate-review objects
+
+### Metadata operations
+- `scripts/validate_metadata_operations.py`
+- validates KMASS metric and metadata remediation examples
+
+### CoC service and SLA contracts
+- `scripts/validate_service_catalog_and_sla.py`
+- validates service catalog entry and SLA examples
+
+### Incentive and payout contracts
+- `scripts/validate_payout_objects.py`
+- validates payout and escrow objects
+- `scripts/validate_incentive_policy.py`
+- validates bounty/incentive policy examples
+
+### Professional Intelligence program contracts
+- `scripts/validate_professional_intelligence.py`
+- validates Professional Intelligence work item, demo acceptance, and repo readiness fixtures
+
+## Rule
+
+Specialized workflows may remain for fast targeted checks, but `validation-suite.yml` is the main consolidation path for repo-wide contract health.

--- a/scripts/run_validation_suite.py
+++ b/scripts/run_validation_suite.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+CANDIDATE_CHECKS = [
+    [sys.executable, str(ROOT / "scripts" / "validate_configs.py")],
+    [sys.executable, str(ROOT / "scripts" / "validate_all_contracts.py")],
+    [sys.executable, str(ROOT / "scripts" / "validate_metadata_operations.py")],
+    [sys.executable, str(ROOT / "scripts" / "validate_service_catalog_and_sla.py")],
+    [sys.executable, str(ROOT / "scripts" / "validate_payout_objects.py")],
+    [sys.executable, str(ROOT / "scripts" / "validate_incentive_policy.py")],
+    [sys.executable, str(ROOT / "scripts" / "validate_professional_intelligence.py")],
+]
+
+
+def main() -> int:
+    failures = 0
+    skipped = 0
+
+    for cmd in CANDIDATE_CHECKS:
+        script = Path(cmd[-1])
+        if not script.exists():
+            print(f"[SKIP] missing {script.relative_to(ROOT)}")
+            skipped += 1
+            continue
+        print(f"[RUN] {' '.join(str(part) for part in cmd)}")
+        result = subprocess.run(cmd, cwd=ROOT, check=False)
+        if result.returncode != 0:
+            failures += 1
+            print(f"[FAIL] {script.relative_to(ROOT)} exited with {result.returncode}")
+        else:
+            print(f"[OK] {script.relative_to(ROOT)}")
+
+    if failures:
+        print(f"[FAIL] validation suite completed with {failures} failed check(s) and {skipped} skipped check(s)")
+        return 1
+
+    print(f"[OK] validation suite completed with {skipped} skipped check(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Add a repo-wide validation suite runner and workflow for `delivery-excellence-automation`.

## Adds

- `scripts/run_validation_suite.py`
- `.github/workflows/validation-suite.yml`
- `docs/validation-suite.md`

## Why

The automation repo now contains multiple contract families: governance automation, agentic services, metadata operations, CoC service/SLA contracts, incentive/payout objects, and Professional Intelligence program contracts. This PR gives contributors one primary operator path for repo-wide contract health while leaving specialized validators available for targeted checks.

## Follow-up

- eventually retire or narrow redundant specialized workflows once the suite proves stable
- connect this to branch protections after GitHub Teams / CODEOWNERS are tightened
