### PR TITLE
Add agent harness metric contracts

### DIFF
--- a/.github/workflows/professional-intelligence-validation.yml
+++ b/.github/workflows/professional-intelligence-validation.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - 'contracts/professional-intelligence/**'
       - 'examples/professional-intelligence/**'
+      - 'contracts/agent-harness/**'
+      - 'examples/agent-harness/**'
       - 'scripts/validate_professional_intelligence.py'
       - '.github/workflows/professional-intelligence-validation.yml'
   push:
@@ -13,6 +15,8 @@ on:
     paths:
       - 'contracts/professional-intelligence/**'
       - 'examples/professional-intelligence/**'
+      - 'contracts/agent-harness/**'
+      - 'examples/agent-harness/**'
       - 'scripts/validate_professional_intelligence.py'
       - '.github/workflows/professional-intelligence-validation.yml'
 
@@ -31,5 +35,5 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Validate Professional Intelligence fixtures
+      - name: Validate Professional Intelligence and Agent Harness fixtures
         run: python3 scripts/validate_professional_intelligence.py

--- a/.github/workflows/professional-intelligence-validation.yml
+++ b/.github/workflows/professional-intelligence-validation.yml
@@ -8,6 +8,7 @@ on:
       - 'contracts/agent-harness/**'
       - 'examples/agent-harness/**'
       - 'scripts/validate_professional_intelligence.py'
+      - 'scripts/generate_agent_harness_readouts.py'
       - '.github/workflows/professional-intelligence-validation.yml'
   push:
     branches:
@@ -18,6 +19,7 @@ on:
       - 'contracts/agent-harness/**'
       - 'examples/agent-harness/**'
       - 'scripts/validate_professional_intelligence.py'
+      - 'scripts/generate_agent_harness_readouts.py'
       - '.github/workflows/professional-intelligence-validation.yml'
 
 permissions:
@@ -37,3 +39,6 @@ jobs:
 
       - name: Validate Professional Intelligence and Agent Harness fixtures
         run: python3 scripts/validate_professional_intelligence.py
+
+      - name: Generate and validate Agent Harness readouts
+        run: python3 scripts/generate_agent_harness_readouts.py --input examples/agent-harness/recent-repo-activity-report.example.json --output-dir build/agent-harness

--- a/contracts/agent-harness/customer-proof-readout.schema.json
+++ b/contracts/agent-harness/customer-proof-readout.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/delex/agent-harness/customer-proof-readout.schema.json",
+  "title": "CustomerProofReadout",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "readoutId", "generatedAt", "audience", "outcomeRef", "workPerformed", "evidenceRefs", "knownLimits"],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "readoutId": { "type": "string" },
+    "generatedAt": { "type": "string" },
+    "audience": { "type": "string", "enum": ["internal", "executive", "customer-safe", "public-demo"] },
+    "outcomeRef": { "type": "string" },
+    "customerRef": { "type": "string" },
+    "workPerformed": { "type": "array", "items": { "type": "string" } },
+    "artifactsChanged": { "type": "array", "items": { "type": "string" } },
+    "approvals": { "type": "array", "items": { "type": "string" } },
+    "valueClaims": { "type": "array", "items": { "type": "string" } },
+    "costSummary": { "type": "string" },
+    "evidenceRefs": { "type": "array", "items": { "type": "string" } },
+    "knownLimits": { "type": "array", "items": { "type": "string" } },
+    "nextDecision": { "type": "string" }
+  }
+}

--- a/contracts/agent-harness/delivery-metric-event.schema.json
+++ b/contracts/agent-harness/delivery-metric-event.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/delex/agent-harness/delivery-metric-event.schema.json",
+  "title": "DeliveryMetricEvent",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "metricEventId", "observedAt", "repo", "metricFamily", "metricName", "value", "unit", "evidenceRef"],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "metricEventId": { "type": "string" },
+    "observedAt": { "type": "string" },
+    "repo": { "type": "string" },
+    "workItemRef": { "type": "string" },
+    "outcomeRef": { "type": "string" },
+    "metricFamily": {
+      "type": "string",
+      "enum": ["throughput", "flow", "quality", "governance", "cost", "reliability", "safety-security", "customer-proof"]
+    },
+    "metricName": { "type": "string" },
+    "value": { "type": "number" },
+    "unit": { "type": "string" },
+    "direction": { "type": "string", "enum": ["higher-is-better", "lower-is-better", "target-band", "informational"] },
+    "evidenceRef": { "type": "string" },
+    "notes": { "type": "string" }
+  }
+}

--- a/contracts/agent-harness/human-control-event.schema.json
+++ b/contracts/agent-harness/human-control-event.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/delex/agent-harness/human-control-event.schema.json",
+  "title": "HumanControlEvent",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "eventId", "observedAt", "actorRef", "eventType", "subjectRef", "decision", "evidenceRef"],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "eventId": { "type": "string" },
+    "observedAt": { "type": "string" },
+    "actorRef": { "type": "string" },
+    "eventType": {
+      "type": "string",
+      "enum": ["approval", "rejection", "override", "clarification", "risk-acceptance", "credential-grant", "scope-change", "promotion-approval"]
+    },
+    "subjectRef": { "type": "string" },
+    "repo": { "type": "string" },
+    "decision": { "type": "string", "enum": ["approved", "rejected", "deferred", "accepted-risk", "revoked"] },
+    "reason": { "type": "string" },
+    "evidenceRef": { "type": "string" },
+    "followUpWorkItemRef": { "type": "string" }
+  }
+}

--- a/contracts/agent-harness/recent-repo-activity-report.schema.json
+++ b/contracts/agent-harness/recent-repo-activity-report.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/delex/agent-harness/recent-repo-activity-report.schema.json",
+  "title": "RecentRepoActivityReport",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "reportId", "generatedAt", "windowDays", "subject", "activities"],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "reportId": { "type": "string" },
+    "generatedAt": { "type": "string" },
+    "windowDays": { "type": "integer" },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["login", "orgs"],
+      "properties": {
+        "login": { "type": "string" },
+        "orgs": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "activities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["repo", "owner", "activityType", "observedAt", "evidenceRef", "deliveryLane"],
+        "properties": {
+          "repo": { "type": "string" },
+          "owner": { "type": "string" },
+          "activityType": {
+            "type": "string",
+            "enum": ["new-repo", "recent-commit", "recent-pr", "recent-issue", "release", "workflow-run", "manual-observation"]
+          },
+          "observedAt": { "type": "string" },
+          "evidenceRef": { "type": "string" },
+          "deliveryLane": {
+            "type": "string",
+            "enum": ["runtime", "governance", "memory", "security", "workstation", "operator-ux", "delivery", "model", "knowledge", "product", "lab", "unknown"]
+          },
+          "summary": { "type": "string" },
+          "followUpRequired": { "type": "boolean" }
+        }
+      }
+    },
+    "links": { "type": "object", "additionalProperties": { "type": "string" } }
+  }
+}

--- a/contracts/agent-harness/scoreboard-snapshot.schema.json
+++ b/contracts/agent-harness/scoreboard-snapshot.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/delex/agent-harness/scoreboard-snapshot.schema.json",
+  "title": "ScoreboardSnapshot",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "snapshotId", "generatedAt", "scoreboardType", "period", "scores"],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "snapshotId": { "type": "string" },
+    "generatedAt": { "type": "string" },
+    "scoreboardType": {
+      "type": "string",
+      "enum": ["estate-readiness", "agent-harness", "product-proof", "skill-mcp", "security-readiness", "customer-proof"]
+    },
+    "period": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start", "end"],
+      "properties": {
+        "start": { "type": "string" },
+        "end": { "type": "string" }
+      }
+    },
+    "scores": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["subjectRef", "score", "status", "evidenceRefs"],
+        "properties": {
+          "subjectRef": { "type": "string" },
+          "score": { "type": "number" },
+          "status": { "type": "string", "enum": ["green", "yellow", "red", "unknown"] },
+          "evidenceRefs": { "type": "array", "items": { "type": "string" } },
+          "blockedBy": { "type": "array", "items": { "type": "string" } },
+          "nextAction": { "type": "string" }
+        }
+      }
+    },
+    "summary": { "type": "string" }
+  }
+}

--- a/contracts/agent-harness/skill-mcp-asset-score.schema.json
+++ b/contracts/agent-harness/skill-mcp-asset-score.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/delex/agent-harness/skill-mcp-asset-score.schema.json",
+  "title": "SkillMCPAssetScore",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "assetScoreId", "generatedAt", "assetType", "assetRef", "trustTier", "score", "status", "evidenceRefs"],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "assetScoreId": { "type": "string" },
+    "generatedAt": { "type": "string" },
+    "assetType": { "type": "string", "enum": ["skill", "mcp-server", "tool-pack", "agent-template"] },
+    "assetRef": { "type": "string" },
+    "ownerRepo": { "type": "string" },
+    "trustTier": { "type": "string", "enum": ["official", "verified", "community", "internal", "quarantined", "deprecated", "revoked"] },
+    "score": { "type": "number" },
+    "status": { "type": "string", "enum": ["usable", "needs-review", "blocked", "deprecated", "revoked"] },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "status"],
+        "properties": {
+          "name": { "type": "string" },
+          "status": { "type": "string", "enum": ["pass", "fail", "warn", "not-applicable"] },
+          "evidenceRef": { "type": "string" }
+        }
+      }
+    },
+    "evidenceRefs": { "type": "array", "items": { "type": "string" } },
+    "nextAction": { "type": "string" }
+  }
+}

--- a/examples/agent-harness/customer-proof-readout.example.json
+++ b/examples/agent-harness/customer-proof-readout.example.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": "v0.1",
+  "readoutId": "customer-proof-governed-agent-harness-2026-05-05",
+  "generatedAt": "2026-05-05T00:00:00Z",
+  "audience": "customer-safe",
+  "outcomeRef": "outcome-governed-agent-harness",
+  "customerRef": "internal-reference-customer",
+  "workPerformed": [
+    "Mapped outcome-driven agent harness lessons to SocioProphet and SourceOS delivery planes.",
+    "Separated runtime, policy, topology, memory, browser, terminal, security, and delivery ownership.",
+    "Defined scoreboards for readiness, proof, human control, and reusable skill/MCP assets."
+  ],
+  "artifactsChanged": [
+    "docs/agent-harness-delivery-operating-model.md",
+    "contracts/agent-harness/*.schema.json"
+  ],
+  "approvals": ["human-control-event://approval-delivery-model-baseline"],
+  "valueClaims": [
+    "Creates a repeatable management surface for agent/human work.",
+    "Improves ability to prove delivery value without exposing sensitive runtime details."
+  ],
+  "costSummary": "No runtime agent execution cost recorded in this example.",
+  "evidenceRefs": [
+    "github://SocioProphet/delivery-excellence/pull/9",
+    "github://SocioProphet/delivery-excellence-automation/tree/work/agent-harness-metrics-contracts/contracts/agent-harness"
+  ],
+  "knownLimits": [
+    "Example readout only; production readouts should be generated from validated evidence packs.",
+    "No customer-sensitive data is included."
+  ],
+  "nextDecision": "Approve automation contracts and wire scoreboard generation."
+}

--- a/examples/agent-harness/delivery-metric-event.example.json
+++ b/examples/agent-harness/delivery-metric-event.example.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "v0.1",
+  "metricEventId": "metric-agentplane-replay-success-2026-05-05",
+  "observedAt": "2026-05-05T00:00:00Z",
+  "repo": "SocioProphet/agentplane",
+  "workItemRef": "agent-harness-runtime-contracts-v0.1",
+  "outcomeRef": "outcome-governed-agent-harness",
+  "metricFamily": "reliability",
+  "metricName": "replay-evidence-present",
+  "value": 1,
+  "unit": "boolean-as-number",
+  "direction": "higher-is-better",
+  "evidenceRef": "github://SocioProphet/agentplane/docs/receipt-lifecycle.md",
+  "notes": "Tracks whether a run or workstream emits replay-ready evidence rather than logs only."
+}

--- a/examples/agent-harness/human-control-event.example.json
+++ b/examples/agent-harness/human-control-event.example.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": "v0.1",
+  "eventId": "approval-delivery-model-baseline",
+  "observedAt": "2026-05-05T00:00:00Z",
+  "actorRef": "github://mdheller",
+  "eventType": "approval",
+  "subjectRef": "github://SocioProphet/delivery-excellence/pull/9",
+  "repo": "SocioProphet/delivery-excellence",
+  "decision": "approved",
+  "reason": "Delivery Excellence is the correct plane for performance stack, corporate metrics, scoreboards, and operating cadence.",
+  "evidenceRef": "github://SocioProphet/delivery-excellence/docs/agent-harness-delivery-operating-model.md",
+  "followUpWorkItemRef": "agent-harness-metrics-contracts-v0.1"
+}

--- a/examples/agent-harness/recent-repo-activity-report.example.json
+++ b/examples/agent-harness/recent-repo-activity-report.example.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": "v0.1",
+  "reportId": "recent-repo-activity-2026-05-05-mdheller-21d",
+  "generatedAt": "2026-05-05T00:00:00Z",
+  "windowDays": 21,
+  "subject": {
+    "login": "mdheller",
+    "orgs": ["SocioProphet", "SourceOS-Linux", "SociOS-Linux"]
+  },
+  "activities": [
+    {
+      "repo": "SocioProphet/agentplane",
+      "owner": "SocioProphet",
+      "activityType": "recent-commit",
+      "observedAt": "2026-05-04T16:21:41-04:00",
+      "evidenceRef": "github://SocioProphet/agentplane/commit/d79db6ffa0d56fdcc2e82500e4cdc7ad787638e3",
+      "deliveryLane": "runtime",
+      "summary": "Agentic PR control plane defined for governed agent work orders.",
+      "followUpRequired": true
+    },
+    {
+      "repo": "SocioProphet/delivery-excellence",
+      "owner": "SocioProphet",
+      "activityType": "recent-commit",
+      "observedAt": "2026-04-29T11:43:27-04:00",
+      "evidenceRef": "github://SocioProphet/delivery-excellence/commit/de9a8514e9dd56ed3c97d218931a0633935c7768",
+      "deliveryLane": "delivery",
+      "summary": "Professional Intelligence delivery model added.",
+      "followUpRequired": false
+    },
+    {
+      "repo": "SourceOS-Linux/BearBrowser",
+      "owner": "SourceOS-Linux",
+      "activityType": "recent-commit",
+      "observedAt": "2026-05-04T19:11:54-04:00",
+      "evidenceRef": "github://SourceOS-Linux/BearBrowser/commit/a2e71207824a6ba0f9ebde42fe1a9579d631b434",
+      "deliveryLane": "operator-ux",
+      "summary": "BearBrowser launcher repair command exposed.",
+      "followUpRequired": true
+    }
+  ],
+  "links": {
+    "dossier": "file://socioprophet_repository_dossier_current_snapshot_2026-04-29.pdf"
+  }
+}

--- a/examples/agent-harness/scoreboard-snapshot.example.json
+++ b/examples/agent-harness/scoreboard-snapshot.example.json
@@ -1,0 +1,34 @@
+{
+  "schemaVersion": "v0.1",
+  "snapshotId": "scoreboard-agent-harness-2026-05-05",
+  "generatedAt": "2026-05-05T00:00:00Z",
+  "scoreboardType": "agent-harness",
+  "period": {
+    "start": "2026-04-14T00:00:00Z",
+    "end": "2026-05-05T00:00:00Z"
+  },
+  "scores": [
+    {
+      "subjectRef": "github://SocioProphet/agentplane",
+      "score": 72,
+      "status": "yellow",
+      "evidenceRefs": [
+        "github://SocioProphet/agentplane/README.md",
+        "github://SocioProphet/agentplane/commit/d79db6ffa0d56fdcc2e82500e4cdc7ad787638e3"
+      ],
+      "blockedBy": ["runtime contract schemas not yet complete"],
+      "nextAction": "Add OutcomeSpec, GraphSpec, SessionEnvelope, EvidencePack, EvolutionPatch, and PromotionGate contracts."
+    },
+    {
+      "subjectRef": "github://SocioProphet/delivery-excellence",
+      "score": 80,
+      "status": "green",
+      "evidenceRefs": [
+        "github://SocioProphet/delivery-excellence/docs/agent-harness-delivery-operating-model.md"
+      ],
+      "blockedBy": [],
+      "nextAction": "Connect scoreboards to automation contracts."
+    }
+  ],
+  "summary": "Initial agent harness scoreboard snapshot for Delivery Excellence operating review."
+}

--- a/examples/agent-harness/skill-mcp-asset-score.example.json
+++ b/examples/agent-harness/skill-mcp-asset-score.example.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": "v0.1",
+  "assetScoreId": "skill-mcp-score-sourceos-browser-terminal-2026-05-05",
+  "generatedAt": "2026-05-05T00:00:00Z",
+  "assetType": "tool-pack",
+  "assetRef": "sourceos://tool-pack/browser-terminal-governed-surfaces",
+  "ownerRepo": "SourceOS-Linux/BearBrowser",
+  "trustTier": "internal",
+  "score": 65,
+  "status": "needs-review",
+  "checks": [
+    {
+      "name": "manifest-present",
+      "status": "warn",
+      "evidenceRef": "github://SourceOS-Linux/BearBrowser/README.md"
+    },
+    {
+      "name": "policy-grants-declared",
+      "status": "warn",
+      "evidenceRef": "github://SocioProphet/policy-fabric"
+    },
+    {
+      "name": "operator-surface-present",
+      "status": "pass",
+      "evidenceRef": "github://SourceOS-Linux/TurtleTerm/README.md"
+    }
+  ],
+  "evidenceRefs": [
+    "github://SourceOS-Linux/BearBrowser",
+    "github://SourceOS-Linux/TurtleTerm"
+  ],
+  "nextAction": "Create governed skill/MCP manifests and SCOPE-D risk checks for browser and terminal tool packs."
+}

--- a/scripts/generate_agent_harness_readouts.py
+++ b/scripts/generate_agent_harness_readouts.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Generate deterministic Agent Harness Delivery Excellence readouts.
+
+The generator consumes a RecentRepoActivityReport and emits a minimal set of
+Delivery Excellence artifacts:
+
+- scoreboard-snapshot.generated.json
+- delivery-metric-event.generated.json
+- customer-proof-readout.generated.json
+
+It intentionally uses only the Python standard library and writes to
+build/agent-harness by default so generated outputs stay out of committed source
+unless a later promotion explicitly checks them in as evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_INPUT = ROOT / "examples/agent-harness/recent-repo-activity-report.example.json"
+DEFAULT_OUTPUT_DIR = ROOT / "build/agent-harness"
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def status_for_score(score: int) -> str:
+    if score >= 80:
+        return "green"
+    if score >= 55:
+        return "yellow"
+    return "red"
+
+
+def build_scoreboard(report: dict[str, Any]) -> dict[str, Any]:
+    activities = report.get("activities", [])
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for activity in activities:
+        grouped[activity["repo"]].append(activity)
+
+    scores = []
+    for repo in sorted(grouped):
+        repo_activities = grouped[repo]
+        follow_up_count = sum(1 for item in repo_activities if item.get("followUpRequired"))
+        evidence_refs = [item["evidenceRef"] for item in repo_activities]
+        base = 60
+        evidence_bonus = min(25, len(evidence_refs) * 5)
+        follow_up_penalty = min(30, follow_up_count * 10)
+        score = max(0, min(100, base + evidence_bonus - follow_up_penalty))
+        scores.append(
+            {
+                "subjectRef": f"github://{repo}",
+                "score": score,
+                "status": status_for_score(score),
+                "evidenceRefs": evidence_refs,
+                "blockedBy": ["follow-up required"] if follow_up_count else [],
+                "nextAction": (
+                    "Resolve follow-up items and attach validated evidence."
+                    if follow_up_count
+                    else "Maintain evidence cadence and keep scoreboard feed current."
+                ),
+            }
+        )
+
+    return {
+        "schemaVersion": "v0.1",
+        "snapshotId": f"scoreboard-agent-harness-{report['reportId']}",
+        "generatedAt": report["generatedAt"],
+        "scoreboardType": "agent-harness",
+        "period": {
+            "start": f"window-{report['windowDays']}-days-before-{report['generatedAt']}",
+            "end": report["generatedAt"],
+        },
+        "scores": scores,
+        "summary": "Generated from recent repository activity report.",
+    }
+
+
+def build_metric_event(report: dict[str, Any]) -> dict[str, Any]:
+    activities = report.get("activities", [])
+    repos = sorted({item["repo"] for item in activities})
+    return {
+        "schemaVersion": "v0.1",
+        "metricEventId": f"metric-activity-count-{report['reportId']}",
+        "observedAt": report["generatedAt"],
+        "repo": "cross-estate",
+        "workItemRef": "agent-harness-absorption-baseline",
+        "outcomeRef": "outcome-governed-agent-harness",
+        "metricFamily": "throughput",
+        "metricName": "recent-activity-repo-count",
+        "value": len(repos),
+        "unit": "repositories",
+        "direction": "higher-is-better",
+        "evidenceRef": f"recent-repo-activity-report://{report['reportId']}",
+        "notes": "Counts unique repositories represented in the recent activity report.",
+    }
+
+
+def build_customer_proof(report: dict[str, Any], scoreboard: dict[str, Any]) -> dict[str, Any]:
+    repos = [score["subjectRef"] for score in scoreboard.get("scores", [])]
+    follow_up = [
+        item["repo"]
+        for item in report.get("activities", [])
+        if item.get("followUpRequired")
+    ]
+    return {
+        "schemaVersion": "v0.1",
+        "readoutId": f"customer-proof-{report['reportId']}",
+        "generatedAt": report["generatedAt"],
+        "audience": "customer-safe",
+        "outcomeRef": "outcome-governed-agent-harness",
+        "customerRef": "internal-reference-customer",
+        "workPerformed": [
+            "Generated a cross-estate activity scoreboard from repository evidence.",
+            "Projected recent activity into Delivery Excellence management artifacts.",
+            "Separated customer-safe readout data from raw runtime payloads.",
+        ],
+        "artifactsChanged": [
+            "build/agent-harness/scoreboard-snapshot.generated.json",
+            "build/agent-harness/delivery-metric-event.generated.json",
+            "build/agent-harness/customer-proof-readout.generated.json",
+        ],
+        "approvals": [],
+        "valueClaims": [
+            f"Recent activity covers {len(repos)} repositories.",
+            "Follow-up work is visible without exposing sensitive runtime details.",
+        ],
+        "costSummary": "Generator records no model or external service cost.",
+        "evidenceRefs": repos,
+        "knownLimits": [
+            "Generated from the provided recent activity report only.",
+            "Does not query GitHub directly; live ingestion belongs in a later automation tranche.",
+        ] + ([f"Follow-up required for: {', '.join(sorted(set(follow_up)))}"] if follow_up else []),
+        "nextDecision": "Wire live GitHub activity ingestion and publish recurring scoreboard snapshots.",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    args = parser.parse_args()
+
+    report = load_json(args.input)
+    scoreboard = build_scoreboard(report)
+    metric_event = build_metric_event(report)
+    customer_proof = build_customer_proof(report, scoreboard)
+
+    write_json(args.output_dir / "scoreboard-snapshot.generated.json", scoreboard)
+    write_json(args.output_dir / "delivery-metric-event.generated.json", metric_event)
+    write_json(args.output_dir / "customer-proof-readout.generated.json", customer_proof)
+
+    print(f"wrote: {args.output_dir / 'scoreboard-snapshot.generated.json'}")
+    print(f"wrote: {args.output_dir / 'delivery-metric-event.generated.json'}")
+    print(f"wrote: {args.output_dir / 'customer-proof-readout.generated.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_agent_harness_readouts.py
+++ b/scripts/generate_agent_harness_readouts.py
@@ -21,14 +21,17 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
+from validate_professional_intelligence import ValidationError, load_json, validate
+
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_INPUT = ROOT / "examples/agent-harness/recent-repo-activity-report.example.json"
 DEFAULT_OUTPUT_DIR = ROOT / "build/agent-harness"
 
-
-def load_json(path: Path) -> Any:
-    with path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
+SCHEMAS = {
+    "scoreboard": ROOT / "contracts/agent-harness/scoreboard-snapshot.schema.json",
+    "metric": ROOT / "contracts/agent-harness/delivery-metric-event.schema.json",
+    "customer_proof": ROOT / "contracts/agent-harness/customer-proof-readout.schema.json",
+}
 
 
 def write_json(path: Path, payload: Any) -> None:
@@ -149,6 +152,17 @@ def build_customer_proof(report: dict[str, Any], scoreboard: dict[str, Any]) -> 
     }
 
 
+def validate_generated(scoreboard: dict[str, Any], metric_event: dict[str, Any], customer_proof: dict[str, Any]) -> None:
+    checks = [
+        ("scoreboard", scoreboard),
+        ("metric", metric_event),
+        ("customer_proof", customer_proof),
+    ]
+    for schema_name, payload in checks:
+        schema = load_json(SCHEMAS[schema_name])
+        validate(schema, payload)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
@@ -159,6 +173,11 @@ def main() -> int:
     scoreboard = build_scoreboard(report)
     metric_event = build_metric_event(report)
     customer_proof = build_customer_proof(report, scoreboard)
+
+    try:
+        validate_generated(scoreboard, metric_event, customer_proof)
+    except ValidationError as exc:
+        raise SystemExit(f"generated readout validation failed: {exc}") from exc
 
     write_json(args.output_dir / "scoreboard-snapshot.generated.json", scoreboard)
     write_json(args.output_dir / "delivery-metric-event.generated.json", metric_event)

--- a/scripts/validate_professional_intelligence.py
+++ b/scripts/validate_professional_intelligence.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Validate Professional Intelligence DelEx automation fixtures.
+"""Validate Professional Intelligence and Agent Harness DelEx automation fixtures.
 
 This validator intentionally uses only the Python standard library. It implements the
-small JSON Schema subset used by this repository's Professional Intelligence schemas:
-required, properties, additionalProperties=false, const, enum, primitive type checks,
-arrays, object properties, and simple union types.
+small JSON Schema subset used by this repository's DelEx schemas: required,
+properties, additionalProperties=false, const, enum, primitive type checks, arrays,
+object properties, and simple union types.
 """
 
 from __future__ import annotations
@@ -28,6 +28,30 @@ PAIRS = [
     (
         ROOT / "contracts/professional-intelligence/repo-readiness.schema.json",
         ROOT / "examples/professional-intelligence/repo-readiness.example.json",
+    ),
+    (
+        ROOT / "contracts/agent-harness/recent-repo-activity-report.schema.json",
+        ROOT / "examples/agent-harness/recent-repo-activity-report.example.json",
+    ),
+    (
+        ROOT / "contracts/agent-harness/delivery-metric-event.schema.json",
+        ROOT / "examples/agent-harness/delivery-metric-event.example.json",
+    ),
+    (
+        ROOT / "contracts/agent-harness/scoreboard-snapshot.schema.json",
+        ROOT / "examples/agent-harness/scoreboard-snapshot.example.json",
+    ),
+    (
+        ROOT / "contracts/agent-harness/customer-proof-readout.schema.json",
+        ROOT / "examples/agent-harness/customer-proof-readout.example.json",
+    ),
+    (
+        ROOT / "contracts/agent-harness/human-control-event.schema.json",
+        ROOT / "examples/agent-harness/human-control-event.example.json",
+    ),
+    (
+        ROOT / "contracts/agent-harness/skill-mcp-asset-score.schema.json",
+        ROOT / "examples/agent-harness/skill-mcp-asset-score.example.json",
     ),
 ]
 
@@ -125,12 +149,12 @@ def main() -> int:
             failures.append(str(exc))
 
     if failures:
-        print("Professional Intelligence validation failed:", file=sys.stderr)
+        print("DelEx automation validation failed:", file=sys.stderr)
         for failure in failures:
             print(f"- {failure}", file=sys.stderr)
         return 1
 
-    print("Professional Intelligence validation passed")
+    print("DelEx automation validation passed")
     return 0
 
 


### PR DESCRIPTION
## Summary

Adds machine-readable Delivery Excellence contracts and a deterministic generator for the agent harness operating model.

This makes the performance stack enforceable instead of prose-only: recent repo activity, delivery metric events, scoreboard snapshots, customer-proof readouts, human-control events, and skill/MCP asset scores now have schemas, examples, validation, and generated readouts from the example activity report.

## Scope

- Adds six `contracts/agent-harness/*.schema.json` files.
- Adds matching examples under `examples/agent-harness/`.
- Extends the existing standard-library validator to cover the new contract/example pairs.
- Adds `scripts/generate_agent_harness_readouts.py` to create scoreboard, metric event, and customer-proof readout artifacts from a recent repo activity report.
- Extends CI to validate fixtures and run the generator.

## Validation

- Branch diff is 17 commits ahead, 0 behind `main`.
- Changed files are limited to schemas, examples, validator, generator, and validation workflow.
- No external dependencies added; generator uses Python standard library only.

## Follow-up

Next tranche should replace example-file input with live GitHub/repo activity ingestion and publish recurring cross-estate scoreboards back to Delivery Excellence and SocioSphere.